### PR TITLE
１コマ漫画ジェネレーターをモーダル内に表示

### DIFF
--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -73,7 +73,7 @@
           <v-card-actions>
             <v-spacer></v-spacer>
             <v-btn
-              color="green darken-1"
+              color="blue-grey"
               text
               @click="isOpenDialog = false"
             >
@@ -95,6 +95,16 @@
     <div v-if="downloadURL" class="mt-6">
       <p class="text-center">カードを保存しました！</p>
       <a :href="downloadURL" target="_blank">保存したカードを表示する</a>
+    </div>
+    <div class="mt-6">
+      <v-btn
+        :disabled="!downloadURL"
+        color="blue-grey"
+        class="white--text"
+        @click="backToSetting"
+      >
+        カードを設定画面に反映させる
+      </v-btn>
     </div>
   </div>
 </template>
@@ -170,6 +180,10 @@ export default Vue.extend({
             })
         }, 'image/png')
       })
+    },
+    backToSetting() {
+      this.$emit('getImageUrl', { imageUrl: this.downloadURL })
+      this.$router.go(-2);
     },
     getRandomString(length: number) {
       const source = 'abcdefghijklmnopqrstuvwxyz'

--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -96,14 +96,21 @@
       <p class="text-center">カードを保存しました！</p>
       <a :href="downloadURL" target="_blank">保存したカードを表示する</a>
     </div>
-    <div class="mt-6">
+    <div class="row justify-space-between mt-6">
+      <v-btn
+        color="blue-grey"
+        text
+        @click="backToSetting"
+      >
+        設定画面に戻る
+      </v-btn>
       <v-btn
         :disabled="!downloadURL"
         color="blue-grey"
         class="white--text"
-        @click="backToSetting"
+        @click="applySetting"
       >
-        カードを設定画面に反映させる
+        設定画面に反映させる
       </v-btn>
     </div>
   </div>
@@ -182,6 +189,10 @@ export default Vue.extend({
       })
     },
     backToSetting() {
+      this.$emit('closeModal')
+      this.$router.go(-2);
+    },
+    applySetting() {
       this.$emit('getImageUrl', { imageUrl: this.downloadURL })
       this.$router.go(-2);
     },

--- a/frontend/pages/setting/manga-generator.vue
+++ b/frontend/pages/setting/manga-generator.vue
@@ -10,7 +10,7 @@
     <div class="mt-6">
       <v-btn
         color="blue-grey"
-        class="white--text"
+        text
         @click="backToSetting"
       >
         設定画面に戻る

--- a/frontend/pages/setting/manga-generator.vue
+++ b/frontend/pages/setting/manga-generator.vue
@@ -2,11 +2,20 @@
   <div>
     <ul class="manga-list">
       <li v-for="i in fileLength" :key="i" class="manga-item">
-        <nuxt-link :to="{path: `/manga-generator/${i}`}">
+        <nuxt-link :to="{path: `/setting/generator/${i}`}">
           <img :src="`/images/manga/${getZeroPad(i, 2)}.png`" alt="" />
         </nuxt-link>
       </li>
     </ul>
+    <div class="mt-6">
+      <v-btn
+        color="blue-grey"
+        class="white--text"
+        @click="backToSetting"
+      >
+        設定画面に戻る
+      </v-btn>
+    </div>
   </div>
 </template>
 
@@ -25,6 +34,10 @@ export default Vue.extend({
     }
   },
   methods: {
+    backToSetting() {
+      this.$emit('closeModal')
+      this.$router.go(-1)
+    },
     getZeroPad(value: number, num: number) {
       const _num = typeof num !== 'undefined' ? num : 2
       return value.toString().padStart(_num, '0')


### PR DESCRIPTION
- １コマ漫画ジェネレーターを設定画面内のモーダル表示としました。
- 設定画面のモーダルを開いたときに、選択したカードがカレント表示されるようにしました。

![スクリーンショット 2022-04-29 21 31 04](https://user-images.githubusercontent.com/14883063/165944812-075209ac-a441-4be0-b714-d1ab5fc7af07.png)
![スクリーンショット 2022-04-29 21 31 23](https://user-images.githubusercontent.com/14883063/165944832-3208017d-cd20-411f-a73f-7cdd0dd592ff.png)
![スクリーンショット 2022-04-29 21 31 34](https://user-images.githubusercontent.com/14883063/165944863-06a2500f-c793-4785-84d5-64494e746c0f.png)
