### PR TITLE
カード生成画面に作家名を表示

### DIFF
--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -235,6 +235,7 @@ img {
 .manga-container {
   position: relative;
   display: inline-block;
+  background-color: #fff;
 }
 .footer-container {
   width: 100%;

--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -11,6 +11,7 @@
           <span v-html="text.substr(1).replace('\n', '<br/>')"></span>
         </p>
       </div>
+      <p class="credit-text">イラスト：白目みさえ</p>
     </div>
     <div class="footer-container">
       <v-alert v-if="downloadURL" type="success" class="mt-6 text-center mx-3" dismissible>
@@ -50,7 +51,7 @@
               </v-icon>
             </v-btn>
           </div>
-        </div> 
+        </div>
         <div class="button-wrap mt-6 mx-auto">
           <v-dialog
             v-model="isOpenDialog"
@@ -271,6 +272,15 @@ img {
     padding: 8px;
     letter-spacing: 0;
   }
+}
+.credit-text {
+  position: absolute;
+  bottom: 5px;
+  right: 10px;
+  margin: 0;
+  font-size: 14px;
+  font-weight: bold;
+  text-shadow: 2px 2px 0 #fff, 2px -2px 0 #fff, -2px 2px 0 #fff, -2px -2px 0 #fff, 2px 0px 0 #fff, 0px 2px 0 #fff, -2px 0px 0 #fff, 0px -2px 0 #fff;
 }
 .input-wrap {
   width: 100%;

--- a/frontend/pages/setting/manga-generator.vue
+++ b/frontend/pages/setting/manga-generator.vue
@@ -66,5 +66,6 @@ img {
   &:nth-child(3n) {
     margin-right: 0;
   }
+  background-color: #fff;
 }
 </style>


### PR DESCRIPTION
close #41 

- カード生成画面に作家名を表示しました
- 画像に透過部分があったので、白背景を敷きました

![スクリーンショット 2022-05-07 17 39 43](https://user-images.githubusercontent.com/14883063/167246769-7219b335-15bc-4dd0-af14-56b53c0a2dff.png)

![スクリーンショット 2022-05-07 17 39 58](https://user-images.githubusercontent.com/14883063/167246772-5dde783b-30fe-4650-8df0-9cbd6299b689.png)

![スクリーンショット 2022-05-07 17 40 41](https://user-images.githubusercontent.com/14883063/167246779-69738816-3294-4e6f-a6b2-8d7748ad4e13.png)
