### PR TITLE
設定画面の画像参照がPCで大きくなりすぎないようにする。

### DIFF
--- a/frontend/pages/setting.vue
+++ b/frontend/pages/setting.vue
@@ -108,6 +108,7 @@
     </v-dialog>
     <v-dialog
       v-model="showImageModal"
+      max-width="500px"
     >
       <v-card>
         <v-img


### PR DESCRIPTION
幅の最大値を設定
<img width="1183" alt="スクリーンショット 2022-05-17 22 57 53" src="https://user-images.githubusercontent.com/2096703/168828681-f00ee34f-c6b1-4982-afd9-9d6282fb6c13.png">

小さい画面では今までと同じ。
<img width="371" alt="スクリーンショット 2022-05-17 22 58 58" src="https://user-images.githubusercontent.com/2096703/168828759-69149117-d6e4-481e-bff5-6040ee34f7e2.png">

