### PR TITLE
aboutに公開終了予定の記述を追加

### DIFF
--- a/frontend/pages/about.vue
+++ b/frontend/pages/about.vue
@@ -7,6 +7,12 @@
     </v-row>
     <v-row justify="center">
       <v-col cols="12" sm="8" md="6">
+        <h3>公開について</h3>
+        <p>このプロジェクトは2022年3月17日の「オンラインアイデアソン」からスタートしました。アプリの公開は2022年6月25日に終了する予定です。</p>
+      </v-col>
+    </v-row>
+    <v-row justify="center">
+      <v-col cols="12" sm="8" md="6">
         <h3>イラストについて</h3>
         一コマ漫画のイラストは白目みさえ様からご提供いただいています。
         <div class="text-center my-4">


### PR DESCRIPTION
いわゆるアプリのアップデート通知的なポジションで、公開終了日の予定を追加してみました。

<img width="684" alt="スクリーンショット 2022-05-29 14 50 18" src="https://user-images.githubusercontent.com/14883063/170854253-8ab58ca7-b530-4a89-bc16-0d364403c199.png">
