### PR TITLE
１コマ漫画ジェネレーターの確認ダイアログにカード画像を表示させる

### DIFF
--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -311,7 +311,6 @@ $first-letter-circle: calc(50px + 35 * (100vw - 360px) / 580);
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 30vh;
 }
 .manga-container {
   position: relative;
@@ -320,9 +319,6 @@ $first-letter-circle: calc(50px + 35 * (100vw - 360px) / 580);
 }
 .footer-container {
   width: 100%;
-  position: fixed;
-  bottom: 0;
-  left: 0;
 }
 .actions-container {
   background-color: #FFFFFF;

--- a/frontend/pages/setting/generator/_imageNumber.vue
+++ b/frontend/pages/setting/generator/_imageNumber.vue
@@ -104,11 +104,12 @@
     </div>
     <v-dialog
       v-model="isOpenConfirm"
-      max-width="290"
+      max-width="600"
       persistent
     >
       <v-card>
         <v-card-title class="text-h6">
+          <div ref="cardPreviewCanvas" />
           カードを保存してゲームに使いますか？
         </v-card-title>
         <v-card-actions>
@@ -150,6 +151,7 @@ type DataType = {
   isOpenConfirm: boolean
   foundedNGWord: boolean
   isApiError: boolean
+  oldCanvas: Node|null
 }
 
 type MethodsType = {
@@ -185,7 +187,8 @@ export default Vue.extend<DataType, MethodsType, ComputedType, unknown>({
       isProcessing: false,
       isOpenConfirm: false,
       foundedNGWord: false,
-      isApiError: false
+      isApiError: false,
+      oldCanvas: null,
     }
   },
   head() {
@@ -287,6 +290,17 @@ export default Vue.extend<DataType, MethodsType, ComputedType, unknown>({
       await this.checkNGWord()
       if (!this.foundedNGWord && !this.isApiError) {
         this.isOpenConfirm = true
+        html2canvas(this.$refs.result as HTMLElement).then((canvas) => {
+          const $cardPreviewCanvas = this.$refs.cardPreviewCanvas as HTMLElement
+          if (!this.oldCanvas) {
+            $cardPreviewCanvas.appendChild(canvas)
+          } else {
+            $cardPreviewCanvas.replaceChild(canvas, this.oldCanvas)
+          }
+          canvas.style.width = '100%'
+          canvas.style.height = 'auto'
+          this.oldCanvas = canvas
+        })
       }
     },
     async checkNGWord(): Promise<void> {


### PR DESCRIPTION
close #107 

- フォーム領域がbottomにfixedになっていたのをやめました。
- 「カードを保存」の確認ダイアログ内にカード画像を表示するようにしました。

タブレット
![スクリーンショット 2022-06-02 12 18 41](https://user-images.githubusercontent.com/14883063/171546313-72db55ac-a42d-4d1f-bad2-3f5d5b231b95.png)

スマートフォン
![スクリーンショット 2022-06-02 12 19 22](https://user-images.githubusercontent.com/14883063/171546362-9c521129-cbad-4758-86a6-f72d2ee36949.png)
